### PR TITLE
make compatible with casc

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,11 @@
             <version>3.0.10</version>
         </dependency>
         <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>structs</artifactId>
+            <version>1.10</version>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.12</version>

--- a/src/main/java/com/orctom/jenkins/plugin/buildtimestamp/BuildTimestampEnvironmentContributor.java
+++ b/src/main/java/com/orctom/jenkins/plugin/buildtimestamp/BuildTimestampEnvironmentContributor.java
@@ -43,8 +43,8 @@ public class BuildTimestampEnvironmentContributor extends EnvironmentContributor
 
 			setTimestamp(timestampProperties, DEFAULT_PROPERTY, format(timestamp, timeZone, pattern, ""));
 
-			Set<Tuple> extraProperties = descriptor.getExtraProperties();
-			for (Tuple property : extraProperties) {
+			Set<BuildTimestampExtraProperty> extraProperties = descriptor.getExtraProperties();
+			for (BuildTimestampExtraProperty property : extraProperties) {
 				setTimestamp(timestampProperties, property.getKey(), format(timestamp, timeZone, property.getValue(), property.getShiftExpression()));
 			}
 		}

--- a/src/main/java/com/orctom/jenkins/plugin/buildtimestamp/BuildTimestampExtraProperty.java
+++ b/src/main/java/com/orctom/jenkins/plugin/buildtimestamp/BuildTimestampExtraProperty.java
@@ -3,20 +3,22 @@ package com.orctom.jenkins.plugin.buildtimestamp;
 import hudson.Extension;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 
 /**
- * key value tuple
+ * key value BuildTimestampExtraProperty
  * Created by hao on 12/16/15.
  */
-public class Tuple extends AbstractDescribableImpl<Tuple> {
+public class BuildTimestampExtraProperty extends AbstractDescribableImpl<BuildTimestampExtraProperty> {
 
 	private String key;
 	private String value;
 	private String shiftExpression;
 
 	@DataBoundConstructor
-	public Tuple(String key, String value, String shiftExpression) {
+	public BuildTimestampExtraProperty(String key, String value, String shiftExpression) {
 		this.key = key;
 		this.value = value;
 		this.shiftExpression = shiftExpression;
@@ -26,16 +28,32 @@ public class Tuple extends AbstractDescribableImpl<Tuple> {
 		return key;
 	}
 
+	@DataBoundSetter
+	public void setKey(String key) {
+		this.key = key;
+	}
+
 	public String getValue() {
 		return value;
+	}
+
+	@DataBoundSetter
+	public void setValue(String value) {
+		this.value = value;
 	}
 
 	public String getShiftExpression() {
 		return shiftExpression;
 	}
 
+	@DataBoundSetter
+	public void setShiftExpression(String shiftExpression) {
+		this.shiftExpression = shiftExpression;
+	}
+
 	@Extension
-	public static class DescriptorImpl extends Descriptor<Tuple> {
+	@Symbol("buildTimestampExtraProperties")
+	public static class DescriptorImpl extends Descriptor<BuildTimestampExtraProperty> {
 		public String getDisplayName() { return ""; }
 	}
 
@@ -44,11 +62,11 @@ public class Tuple extends AbstractDescribableImpl<Tuple> {
 		if (this == o) return true;
 		if (o == null || getClass() != o.getClass()) return false;
 
-		Tuple tuple = (Tuple) o;
+		BuildTimestampExtraProperty buildTimestampExtraProperty = (BuildTimestampExtraProperty) o;
 
-		if (!key.equals(tuple.key)) return false;
-		if (!value.equals(tuple.value)) return false;
-		return shiftExpression.equals(tuple.shiftExpression);
+		if (!key.equals(buildTimestampExtraProperty.key)) return false;
+		if (!value.equals(buildTimestampExtraProperty.value)) return false;
+		return shiftExpression.equals(buildTimestampExtraProperty.shiftExpression);
 	}
 
 	@Override

--- a/src/main/java/com/orctom/jenkins/plugin/buildtimestamp/BuildTimestampWrapper.java
+++ b/src/main/java/com/orctom/jenkins/plugin/buildtimestamp/BuildTimestampWrapper.java
@@ -9,6 +9,8 @@ import hudson.util.ComboBoxModel;
 import hudson.util.FormValidation;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 
@@ -24,12 +26,13 @@ import static com.orctom.jenkins.plugin.buildtimestamp.BuildTimestampPlugin.DEFA
 public class BuildTimestampWrapper extends BuildWrapper {
 
 	@Extension
+	@Symbol("buildTimestamp")
 	public static final class DescriptorImpl extends BuildWrapperDescriptor {
 
 		private boolean enableBuildTimestamp = true;
 		private String timezone = TimeZone.getDefault().getID();
 		private String pattern = DEFAULT_PATTERN;
-		private Set<Tuple> extraProperties = new HashSet<Tuple>();
+		private Set<BuildTimestampExtraProperty> extraProperties = new HashSet<BuildTimestampExtraProperty>();
 
 		public DescriptorImpl() {
 			load();
@@ -49,6 +52,11 @@ public class BuildTimestampWrapper extends BuildWrapper {
 
 		@Override
 		public boolean configure(StaplerRequest req, JSONObject formData) throws Descriptor.FormException {
+			// reset optional authentication to default before data-binding
+			this.enableBuildTimestamp = false;
+			this.timezone = null;
+			this.pattern = null;
+
 			JSONObject data = formData.getJSONObject("enableBuildTimestamp");
 
 			if (isNullJSONObject(data)) {
@@ -63,7 +71,7 @@ public class BuildTimestampWrapper extends BuildWrapper {
 				if (null != extraPropertyValues) {
 					extraProperties = extractExtraProperties(extraPropertyValues);
 				} else {
-					extraProperties = new HashSet<Tuple>();
+					extraProperties = new HashSet<BuildTimestampExtraProperty>();
 				}
 			}
 
@@ -75,8 +83,8 @@ public class BuildTimestampWrapper extends BuildWrapper {
 			return null == data || data.isNullObject() || data.isEmpty();
 		}
 
-		private Set<Tuple> extractExtraProperties(Object extraPropertyValues) {
-			Set<Tuple> properties = new HashSet<Tuple>();
+		private Set<BuildTimestampExtraProperty> extractExtraProperties(Object extraPropertyValues) {
+			Set<BuildTimestampExtraProperty> properties = new HashSet<BuildTimestampExtraProperty>();
 			if (extraPropertyValues instanceof JSONArray) {
 				JSONArray array = (JSONArray) extraPropertyValues;
 				for (Object item : array) {
@@ -89,13 +97,13 @@ public class BuildTimestampWrapper extends BuildWrapper {
 			return properties;
 		}
 
-		private void addProperty(Set<Tuple> properties, Object obj) {
+		private void addProperty(Set<BuildTimestampExtraProperty> properties, Object obj) {
 			JSONObject data = (JSONObject) obj;
 			String key = data.getString("key");
 			String value = data.getString("value");
 			String shiftExpression = data.getString("shiftExpression");
 			if (isVariableNameValid(key) && isPatternValid(value) && ShiftExpressionHelper.isShiftExpressionValid(shiftExpression)) {
-				properties.add(new Tuple(key, value, shiftExpression));
+				properties.add(new BuildTimestampExtraProperty(key, value, shiftExpression));
 			}
 		}
 
@@ -171,16 +179,36 @@ public class BuildTimestampWrapper extends BuildWrapper {
 			return enableBuildTimestamp;
 		}
 
+        @DataBoundSetter
+        public void setEnableBuildTimestamp(boolean enableBuildTimestamp) {
+            this.enableBuildTimestamp = enableBuildTimestamp;
+        }
+
 		public String getPattern() {
 			return pattern;
 		}
+
+        @DataBoundSetter
+        public void setPattern(String pattern) {
+            this.pattern = pattern;
+        }
 
 		public String getTimezone() {
 			return timezone;
 		}
 
-		public Set<Tuple> getExtraProperties() {
+        @DataBoundSetter
+        public void setTimezone(String timezone) {
+            this.timezone = timezone;
+        }
+
+		public Set<BuildTimestampExtraProperty> getExtraProperties() {
 			return extraProperties;
 		}
+
+        @DataBoundSetter
+        public void setExtraProperties(Set<BuildTimestampExtraProperty> extraProperties) {
+            this.extraProperties = extraProperties;
+        }
 	}
 }


### PR DESCRIPTION
Add some java annotations and setters to make the plugin compatible with https://github.com/jenkinsci/configuration-as-code-plugin

Also renamed Tuple to BuildTimestampExtraProperty as it make more understandable with casc's documentation.