### PR TITLE
Require Jenkins 2.332.4 and update parent pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.565.3</version>
+        <version>4.47</version>
     </parent>
     <artifactId>build-timestamp</artifactId>
     <version>1.0.4-SNAPSHOT</version>
@@ -20,6 +20,7 @@
     </scm>
 
     <properties>
+        <jenkins.version>2.332.4</jenkins.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <spotbugs.excludeFilterFile>${project.basedir}/src/spotbugs/spotbugs-excludes.xml</spotbugs.excludeFilterFile>
     </properties>
@@ -84,7 +85,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
-            <version>1.10</version>
+            <version>324.va_f5d6774f3a_d</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -21,8 +21,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.6</maven.compiler.source>
-        <maven.compiler.target>1.6</maven.compiler.target>
+        <spotbugs.excludeFilterFile>${project.basedir}/src/spotbugs/spotbugs-excludes.xml</spotbugs.excludeFilterFile>
     </properties>
 
     <developers>

--- a/src/main/resources/com/orctom/jenkins/plugin/buildtimestamp/BuildTimestampWrapper/global.jelly
+++ b/src/main/resources/com/orctom/jenkins/plugin/buildtimestamp/BuildTimestampWrapper/global.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
     <f:section title="Build Timestamp" >
         <f:optionalBlock field="enableBuildTimestamp" title="Enable BUILD_TIMESTAMP" checked="${enableBuildTimestamp}"

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <!--
   This view is used to render the installed plugins page.
 -->

--- a/src/spotbugs/spotbugs-excludes.xml
+++ b/src/spotbugs/spotbugs-excludes.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FindBugsFilter>
+  <!--
+    Exclusions in this section have been triaged and determined to be false positives.
+  -->
+
+  <!--
+    Here lies technical debt. Exclusions in this section have not yet been triaged. When working on
+    on this section, pick an exclusion to triage, then:
+    - If it is a false positive, add a @SuppressFBWarnings(value = "[…]", justification = "[…]")
+      annotation indicating the reason why it is a false positive, then remove the exclusion from
+      this section.
+    - If it is not a false positive, fix the bug, then remove the exclusion from this section.
+   -->
+  <Match>
+    <Or>
+      <And>
+        <Bug pattern="ES_COMPARING_PARAMETER_STRING_WITH_EQ"/>
+        <Class name="com.orctom.jenkins.plugin.buildtimestamp.ShiftExpressionHelper"/>
+      </And>
+      <And>
+        <Bug pattern="DM_BOXED_PRIMITIVE_FOR_PARSING"/>
+        <Class name="com.orctom.jenkins.plugin.buildtimestamp.ShiftExpressionHelper"/>
+      </And>
+    </Or>
+  </Match>
+</FindBugsFilter>


### PR DESCRIPTION
## Require Jenkins 2.332.4 and update parent pom

- Escape jelly content by default
- Exclude two spotbugs warnings (debt)
- Require Jenkins 2.332.4 or newer (use most recent parent pom)

Note that this needed to combine multiple changes before any one of them could be completed.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
