### PR TITLE
Use https for scm URL, read only access without credentials

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <scm>
         <url>https://github.com/jenkinsci/build-timestamp-plugin/</url>
-        <connection>scm:git:git@github.com:jenkinsci/build-timestamp-plugin.git</connection>
+	<connection>scm:git:https://github.com/jenkinsci/build-timestamp-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/build-timestamp-plugin.git</developerConnection>
         <tag>HEAD</tag>
     </scm>


### PR DESCRIPTION
## Use https for SCM URL

Allow read only access without credentials.  GitHub has dropped support for the unauthenticated git:// protocol.  This replaces it with the https:// protocol.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
