### PR TITLE
Test with Java 21

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,18 +1,15 @@
-#!/usr/bin/env groovy
-
 /* `buildPlugin` step provided by: https://github.com/jenkins-infra/pipeline-library */
 buildPlugin(
+  // Run a JVM per core in tests
+  forkCount: '1C',
   // Container agents start faster and are easier to administer
   useContainerAgent: true,
   // Show failures on all configurations
   failFast: false,
-  // Opt-in to the Artifact Caching Proxy, to be removed when it will be opt-out.
-  // See https://github.com/jenkins-infra/helpdesk/issues/2752 for more details and updates.
-  artifactCachingProxyEnabled: true,
-  // Test Java 11 with a recent LTS, Java 17 even more recent
+  // Test Java 11, 17, and 21
   configurations: [
-    [platform: 'linux',   jdk: '17', jenkins: '2.380'],
-    [platform: 'linux',   jdk: '11', jenkins: '2.375.1'],
+    [platform: 'linux',   jdk: '17'],
+    [platform: 'linux',   jdk: '21', jenkins: '2.414'],
     [platform: 'windows', jdk: '11']
   ]
 )


### PR DESCRIPTION
## Test with Java 21

Java 21 is scheduled to release September 19, 2023.  We'd like to be ready to support it soon after it releases.  Run plugin tests with Java 21 as preparation.

### Testing done

Confirmed that automated tests pass

### Submitter checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
