### PR TITLE
Require Jenkins 2.479.1 and Jakarta EE 9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.88</version>
+        <version>5.6</version>
         <relativePath />
     </parent>
     <artifactId>build-timestamp</artifactId>
@@ -25,19 +25,11 @@
         <changelist>-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/build-timestamp-plugin</gitHubRepo>
         <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-        <jenkins.baseline>2.452</jenkins.baseline>
-        <jenkins.version>${jenkins.baseline}.4</jenkins.version>
+        <jenkins.baseline>2.479</jenkins.baseline>
+        <jenkins.version>${jenkins.baseline}.1</jenkins.version>
         <spotbugs.effort>Max</spotbugs.effort>
         <spotbugs.threshold>Low</spotbugs.threshold>
     </properties>
-
-    <developers>
-        <developer>
-            <id>orctom</id>
-            <name>Hao CHEN</name>
-            <email>orctom@gmail.com</email>
-        </developer>
-    </developers>
 
     <repositories>
         <repository>
@@ -63,23 +55,4 @@
             <url>https://repo.jenkins-ci.org/snapshots/</url>
         </snapshotRepository>
     </distributionManagement>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-${jenkins.baseline}.x</artifactId>
-                <version>3944.v1a_e4f8b_452db_</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
-    <dependencies>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>structs</artifactId>
-        </dependency>
-    </dependencies>
 </project>

--- a/src/main/java/com/orctom/jenkins/plugin/buildtimestamp/BuildTimestampPlugin.java
+++ b/src/main/java/com/orctom/jenkins/plugin/buildtimestamp/BuildTimestampPlugin.java
@@ -1,19 +1,5 @@
 package com.orctom.jenkins.plugin.buildtimestamp;
 
-import hudson.EnvVars;
-import hudson.Extension;
-import hudson.Launcher;
-import hudson.model.*;
-import hudson.model.listeners.RunListener;
-import jenkins.model.Jenkins;
-import net.sf.json.JSONArray;
-import net.sf.json.JSONObject;
-import org.kohsuke.stapler.StaplerRequest;
-
-import java.io.IOException;
-import java.text.SimpleDateFormat;
-import java.util.*;
-
 /**
  * set build timestamp property to build
  * Created by hao on 12/15/15.

--- a/src/main/java/com/orctom/jenkins/plugin/buildtimestamp/BuildTimestampWrapper.java
+++ b/src/main/java/com/orctom/jenkins/plugin/buildtimestamp/BuildTimestampWrapper.java
@@ -85,8 +85,7 @@ public class BuildTimestampWrapper extends BuildWrapper {
 
 		private Set<BuildTimestampExtraProperty> extractExtraProperties(Object extraPropertyValues) {
 			Set<BuildTimestampExtraProperty> properties = new HashSet<BuildTimestampExtraProperty>();
-			if (extraPropertyValues instanceof JSONArray) {
-				JSONArray array = (JSONArray) extraPropertyValues;
+			if (extraPropertyValues instanceof JSONArray array) {
 				for (Object item : array) {
 					addProperty(properties, item);
 				}

--- a/src/main/java/com/orctom/jenkins/plugin/buildtimestamp/BuildTimestampWrapper.java
+++ b/src/main/java/com/orctom/jenkins/plugin/buildtimestamp/BuildTimestampWrapper.java
@@ -12,7 +12,7 @@ import net.sf.json.JSONObject;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 
 import java.text.SimpleDateFormat;
 import java.util.*;
@@ -51,7 +51,7 @@ public class BuildTimestampWrapper extends BuildWrapper {
 		}
 
 		@Override
-		public boolean configure(StaplerRequest req, JSONObject formData) throws Descriptor.FormException {
+		public boolean configure(StaplerRequest2 req, JSONObject formData) throws Descriptor.FormException {
 			// reset optional authentication to default before data-binding
 			this.enableBuildTimestamp = false;
 			this.timezone = null;


### PR DESCRIPTION
## Require Jenkins 2.479.1 and Jakarta EE 9

Removes the outdated and unused developers section of the pom.

Removes the unnecessary dependency on the structs plugin.

Removes the unnecessary use of the plugin BOM.

Remove unused imports

Uses Java 17 pattern matching instanceof

### Testing done

Confirmed that automated tests pass.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
